### PR TITLE
Adds #mock and #restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Usage
 
 ```javascript
 describe('#getSomething', function() {
+  
+  // Mocks the request objects in http and https.
+  before(hmock.mock);
+  
+  // Restores the original request objects to http and https.
+  after(hmock.restore);
+  
   it('should make a GET request and get a response', function(done) {
     var expectedResponse = { 
       ok: true 

--- a/src/hmock.js
+++ b/src/hmock.js
@@ -38,7 +38,7 @@ function hmock() {
     https.request = function mockRequest(options, callback) {
       return new MockedRequest(options, expectations.shift(), callback);
     };
-  }
+  };
   
   /**
    * Creates and returns a new expectation to be configured.

--- a/src/hmock.js
+++ b/src/hmock.js
@@ -9,31 +9,36 @@ var RequestExpectation = require('./requestExpectation');
 function hmock() {
   // expectation collection
   expectations = [];
-
-  // save the original
-  http._request = http.request;
-  https._request = https.request;
-
+  
   /**
-   * Override http.request
-   *
-   * DISCLAIMER: I know most people think this is a horrible
-   *             practice; I agree, but at the end of the day
-   *             this gets the job done and it is only meant 
-   *             to be used during unit testing anyway.
+   * Overrides http.request and https.request with a mocks and stores the originals in http._request and https._request respectivly.
    */
-  http.request = function (options, callback) {
-    return new MockedRequest(options, expectations.shift(), callback);
-  };
-
-  /**
-   * Override https.request
-   *
-   * DISCLAIMER: SEE ABOVE
-   */
-  https.request = function (options, callback) {
-    return new MockedRequest(options, expectations.shift(), callback);
-  };
+  this.mock = function () {
+    // save the original
+    http._request = http.request;
+    https._request = https.request;
+  
+    /**
+    * Override http.request
+    *
+    * DISCLAIMER: I know most people think this is a horrible
+    *             practice; I agree, but at the end of the day
+    *             this gets the job done and it is only meant 
+    *             to be used during unit testing anyway.
+    */
+    http.request = function mockRequest(options, callback) {
+      return new MockedRequest(options, expectations.shift(), callback);
+    };
+  
+    /**
+    * Override https.request
+    *
+    * DISCLAIMER: SEE ABOVE
+    */
+    https.request = function mockRequest(options, callback) {
+      return new MockedRequest(options, expectations.shift(), callback);
+    };
+  }
   
   /**
    * Creates and returns a new expectation to be configured.
@@ -62,6 +67,22 @@ function hmock() {
       throw new Error('Not all expectations were met during the test.');
     }
   };
+  
+  /**
+   * Restores the original request functions to http and https respectivly.
+   */
+  this.restore = function () {
+    restoreRequest(http);
+    restoreRequest(https);
+  };
+  
+  function restoreRequest (agnosticHttp) {
+    if (agnosticHttp.request.name === 'mockRequest' && agnosticHttp._request) {
+      agnosticHttp.request = agnosticHttp._request;
+      delete agnosticHttp._request;
+    }
+  }
+  
 }
 
 /**

--- a/test/hmock.tests.js
+++ b/test/hmock.tests.js
@@ -1,14 +1,36 @@
 /*jshint expr: true*/
 
 var http = require('http');
+var https = require('https');
 var hmock = require('../src/hmock');
 var expect = require('chai').expect;
 var RequestExpectation = require('../src/requestExpectation');
 
 describe('hmock', function () {
   describe('#()', function () {
-    it('should set the original request function to a "_request" property on the http module', function () {
-      expect(http._request).to.be.defined;
+    it('should not mock the request object until required to do so', function () {
+      expect(http._request).to.not.exist;
+      expect(https._request).to.not.exist;
+    });
+  });
+  
+  describe('#mock', function () {
+    it('should mock the request object of both http and https', function () {
+      hmock.mock();
+      expect(http.request).to.be.an.instanceOf(Function);
+      expect(http.request.name).to.eql('mockRequest');
+      expect(https.request).to.be.an.instanceOf(Function);
+      expect(https.request.name).to.eql('mockRequest');
+    });
+  });
+  
+  describe('#restore', function () {
+    it('should restore the original request function to http and https.', function () {
+      hmock.restore();
+      expect(http.request.name).to.not.eql('mockRequest');
+      expect(https.request.name).to.not.eql('mockRequest');
+      expect(http._request).to.not.exist;
+      expect(https._request).to.not.exist;
     });
   });
 

--- a/test/http.tests.js
+++ b/test/http.tests.js
@@ -87,6 +87,11 @@ function MyClass() {
 }
 
 describe('hmock.http', function () {
+  
+  before(hmock.mock);
+  
+  after(hmock.restore);
+  
   describe('#getSomething', function () {
     it('should make a GET request and get a response', function (done) {
       var expectedResponse = { ok: true };

--- a/test/https.tests.js
+++ b/test/https.tests.js
@@ -89,6 +89,11 @@ function MyClass() {
 }
 
 describe('hmock.https', function () {
+  
+  before(hmock.mock);
+  
+  after(hmock.restore);
+  
   describe('#getSomething', function () {
     it('should make a GET request and get a response', function (done) {
       var expectedResponse = { ok: true };

--- a/test/request.tests.js
+++ b/test/request.tests.js
@@ -34,6 +34,11 @@ function MyClass() {
 }
 
 describe('hmock.request', function () {
+  
+  before(hmock.mock);
+  
+  after(hmock.restore);
+  
   describe('#getSomething', function () {
     it('should make a GET request and get a response', function (done) {
       var expectedResponse = { ok: true };


### PR DESCRIPTION
Added two new methods: `mock` and `restore` in the hmock object.

The general idea is these methods can be used to actually mock and release the mock respectively. I needed to do this because when the library is loaded is interfering with other request which  I rather were not mocked.

Now, when using the library is necessary to actually mock the request objects before it works properly.

``` JavaScript
describe('hmock.https', function () {  
   before(hmock.mock);
    after(hmock.restore);
....
```

Also, I tried to fix the request tests but I had to gave up. That is a weird one.
